### PR TITLE
Fixed admin config section ordering bug 

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Tabs.php
@@ -81,11 +81,19 @@ class Mage_Adminhtml_Block_System_Config_Tabs extends Mage_Adminhtml_Block_Widge
         $sections = $configFields->getSections($current);
         $tabs     = (array)$configFields->getTabs()->children();
 
-
-        $sections = (array)$sections;
-
-        usort($sections, array($this, '_sort'));
         usort($tabs, array($this, '_sort'));
+
+        $tabSections = array();
+        foreach ((array)$sections as $section) {
+            $tab = (string)$section->tab;
+            if (!empty($tab)) {
+                if (!isset($tabSections[$tab])) {
+                    $tabSections[$tab] = array();
+                }
+                $tabSections[$tab][] = $section;
+            }
+        }
+        $sections = array();
 
         foreach ($tabs as $tab) {
             $helperName = $configFields->getAttributeModule($tab);
@@ -95,6 +103,12 @@ class Mage_Adminhtml_Block_System_Config_Tabs extends Mage_Adminhtml_Block_Widge
                 'label' => $label,
                 'class' => (string) $tab->class
             ));
+
+            if (isset($tabSections[$tab->getName()])) {
+                $section = $tabSections[$tab->getName()];
+                usort($section, array($this, '_sort'));
+                $sections = array_merge($sections, $section);
+            }
         }
 
 


### PR DESCRIPTION
The config section sort_order was updated to respect the containing
tab's sort order in addition to the section sort order.  Now sections
are sorted in the context of the tab and the final list of sections is
built first on the tab sort_order, then the section sort_order.  This
fixes a problem with sections that do not have a sort_order becoming the
default section.  The default section is now the first section of the
first tab.
