### PR TITLE
Fixing broken classname resolver during init stage

### DIFF
--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -1228,19 +1228,21 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
 
         // First - check maybe the entity class was rewritten
         $className = null;
-        if (isset($config->rewrite->$class)) {
-            $className = (string)$config->rewrite->$class;
-        } else {
-            /**
-             * Backwards compatibility for pre-MMDB extensions.
-             * In MMDB release resource nodes <..._mysql4> were renamed to <..._resource>. So <deprecatedNode> is left
-             * to keep name of previously used nodes, that still may be used by non-updated extensions.
-             */
-            if ($config->deprecatedNode) {
-                $deprecatedNode = $config->deprecatedNode;
-                $configOld = $this->_xml->global->{$groupType.'s'}->$deprecatedNode;
-                if (isset($configOld->rewrite->$class)) {
-                    $className = (string) $configOld->rewrite->$class;
+        if($config) {
+            if (isset($config->rewrite->$class)) {
+                $className = (string)$config->rewrite->$class;
+            } else {
+                /**
+                 * Backwards compatibility for pre-MMDB extensions.
+                 * In MMDB release resource nodes <..._mysql4> were renamed to <..._resource>. So <deprecatedNode> is left
+                 * to keep name of previously used nodes, that still may be used by non-updated extensions.
+                 */
+                if ($config->deprecatedNode) {
+                    $deprecatedNode = $config->deprecatedNode;
+                    $configOld = $this->_xml->global->{$groupType.'s'}->$deprecatedNode;
+                    if (isset($configOld->rewrite->$class)) {
+                        $className = (string) $configOld->rewrite->$class;
+                    }
                 }
             }
         }


### PR DESCRIPTION
During init stage, when the config XML is not fully loaded, if certain
tasks fail, they throw exceptions and use the core helper to translate
the messages.

If the classname resolver cannot find a specific config section for a
requested module, it defaults to treating the module alias as a
sub-namespace under Mage.  So, a request for 'core/data' would, in the
absence of a valid config, resolve the module portion to Mage_Core.

This was fine until a check for the deprecatedNode element was added in
1.6 that broke this process.  The check is assuming that the $config
variable is a valid config section when it could actually be a NULL
instead. Since the check ignores this possible outcome, it tries to
access a property on a NULL value causing a PHP error.

This patch simply wraps the vulnerable code section and checks that
$config is not a null value.
