### PR TITLE
Incorrect usage of connect/session vs. adminhtml/session

### DIFF
--- a/app/code/core/Mage/CurrencySymbol/controllers/Adminhtml/System/CurrencysymbolController.php
+++ b/app/code/core/Mage/CurrencySymbol/controllers/Adminhtml/System/CurrencysymbolController.php
@@ -69,7 +69,7 @@ class Mage_CurrencySymbol_Adminhtml_System_CurrencysymbolController extends Mage
 
         try {
             Mage::getModel('currencysymbol/system_currencysymbol')->setCurrencySymbolsData($symbolsDataArray);
-            Mage::getSingleton('connect/session')->addSuccess(
+            Mage::getSingleton('adminhtml/session')->addSuccess(
                 Mage::helper('currencysymbol')->__('Custom currency symbols were applied successfully.')
             );
         } catch (Exception $e) {


### PR DESCRIPTION
The Mage_CurrencySymbol module has an incorrect reference to the connect/session class.  It should, from what I can tell, actually be the adminhtml/session class that they use instead.
