### PR TITLE
Fixing URL generation for admin and in APIs

### DIFF
--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -574,17 +574,17 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
     }
 
     /**
-     * Remove script file name from url in case when server rewrites are enabled
+     * Add index filename to URL during installation or if URL rewrites are disabled
+     *
+     * Is we are adding the filename AND the custom_entry_point flag is set,
+     * then force usage of index.php for the filename instead of using $_SERVER
      *
      * @param   string $url
      * @return  string
      */
     protected function _updatePathUseRewrites($url)
     {
-        if ($this->isAdmin()
-            || !$this->getConfig(self::XML_PATH_USE_REWRITES)
-            || !Mage::isInstalled()
-        ) {
+        if (!Mage::isInstalled() || !$this->getConfig(self::XML_PATH_USE_REWRITES)) {
             if ($this->_isCustomEntryPoint()) {
                 $indexFileName = 'index.php';
             } else {


### PR DESCRIPTION
In the admin area (and in api.php) the URL generator was forcing the
usage of index.php even if the use of rewrites was enabled.  This
resulted in URLs for admin always starting with /index.php/admin/ and
looking ugly.

I removed the check for being in the admin area and re-ordered the two
remaining checks (installed, rewrites enabled) to optimize their order.
