### PR TITLE
Fixed bug EAV abstract entity collection object

### DIFF
--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -1424,7 +1424,7 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
     public function toArray($arrAttributes = array())
     {
         $arr = array();
-        foreach ($this->_items as $k => $item) {
+        foreach ($this as $k => $item) {
             $arr[$k] = $item->toArray($arrAttributes);
         }
         return $arr;


### PR DESCRIPTION
The call to toArray() in Mage_Eav_Model_Entity_Collection_Abstract was
broken as it was iterating over $this->_items directly instead of using
the IteratorAggregate interface to iterate over the collection directly
via $this

The $this->_items array is not populated until a call to load() has
happened on a collection.  The getIterator() method internally calls
load() before wrapping $this->_items in an iterator object.

The toXml method was actually using $this to iterate over collection
items and functioning properly while toArray was not.
