### PR TITLE
if autoloader does not find file, allow next autoloader to try

### DIFF
--- a/lib/Varien/Autoload.php
+++ b/lib/Varien/Autoload.php
@@ -90,7 +90,7 @@ class Varien_Autoload
         }
         $classFile.= '.php';
         //echo $classFile;die();
-        if (!stream_resolve_include_path($classFile)) {
+        if (!file_exists($classFile)) {
             return false;
         }
         return include $classFile;

--- a/lib/Varien/Autoload.php
+++ b/lib/Varien/Autoload.php
@@ -90,6 +90,9 @@ class Varien_Autoload
         }
         $classFile.= '.php';
         //echo $classFile;die();
+        if (!stream_resolve_include_path($classFile)) {
+            return false;
+        }
         return include $classFile;
     }
 


### PR DESCRIPTION
put an 

function a ($c) {
    if($c=='hahahaha'){
        class hahahaha {} // Usually "include 'path/to/file.php';"
    }
}
spl_autoload_register('a');

anywhere in the code (after mageplus autoloader was aktivated)

this autoloader gets never executed, because of the include which is always tried in mageplus autoloader.

This patch makes it possible, to use the typical autoload feature of autoloader chaining.
