### PR TITLE
Bugfix: Visibility was set to default when updating a product via ImportExport

### DIFF
--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Abstract.php
@@ -301,11 +301,25 @@ abstract class Mage_ImportExport_Model_Import_Entity_Product_Type_Abstract
                 } elseif (array_key_exists($attrCode, $rowData)) {
                     $resultAttrs[$attrCode] = $rowData[$attrCode];
                 } elseif (null !== $attrParams['default_value']) {
-                    $resultAttrs[$attrCode] = $attrParams['default_value'];
+                    if ($this->_isSkuNew($rowData['sku'])) {
+                        $resultAttrs[$attrCode] = $attrParams['default_value'];
+                    }
                 }
             }
         }
         return $resultAttrs;
+    }
+
+    /**
+     * Check if the given sku belongs to a new product or an existing one
+     *
+     * @param string $sku
+     * @return bool
+     */
+    protected function _isSkuNew($sku)
+    {
+        $oldSkus = $this->_entityModel->getOldSku();
+        return !isset($oldSkus[$sku]);
     }
 
     /**


### PR DESCRIPTION
Bugfix for ImportExport: If an attribute column is not given, it is reset to default value on import (i.e. for visibility, most other attributes don't have a default value). Fixed for updating existing products. See http://www.avs-webentwicklung.de/nc/blog/artikel/magento-importexport-der-visibility-bug.html (German only, sorry)
