### PR TITLE
Newsletter subscriptions count should be configurable

### DIFF
--- a/app/code/core/Mage/Newsletter/Model/Observer.php
+++ b/app/code/core/Mage/Newsletter/Model/Observer.php
@@ -32,6 +32,16 @@
 class Mage_Newsletter_Model_Observer
 {
     /**
+     * @var string
+     */
+    const XML_PATH_NEWSLETTER_SENDING_COUNT_QUEUE = 'newsletter/sending/count_of_queue';
+
+    /**
+     * @var string
+     */
+    const XML_PATH_NEWSLETTER_SENDING_COUNT_SUBSCRIBER = 'newsletter/sending/count_of_subscriptions';
+
+    /**
      * @todo
      *
      * @param $observer
@@ -63,15 +73,15 @@ class Mage_Newsletter_Model_Observer
     }
 
     /**
-     * @todo
+     * Schedules the sending process of the newsletters
      *
      * @param $schedule
      * @return
      */
     public function scheduledSend($schedule)
     {
-        $countOfQueue  = 3;
-        $countOfSubscritions = 20;
+        $countOfQueue = (int) Mage::getStoreConfig(self::XML_PATH_NEWSLETTER_SENDING_COUNT_QUEUE);
+        $countOfSubscriptions = (int) Mage::getStoreConfig(self::XML_PATH_NEWSLETTER_SENDING_COUNT_SUBSCRIBER);
 
         $collection = Mage::getModel('newsletter/queue')->getCollection()
             ->setPageSize($countOfQueue)
@@ -79,6 +89,6 @@ class Mage_Newsletter_Model_Observer
             ->addOnlyForSendingFilter()
             ->load();
 
-         $collection->walk('sendPerSubscriber', array($countOfSubscritions));
+         $collection->walk('sendPerSubscriber', array($countOfSubscriptions));
     }
 }

--- a/app/code/core/Mage/Newsletter/etc/config.xml
+++ b/app/code/core/Mage/Newsletter/etc/config.xml
@@ -195,6 +195,8 @@
             </subscription>
             <sending>
                 <set_return_path>0</set_return_path>
+                <count_of_queue>3</count_of_queue>
+                <count_of_subscriptions>20</count_of_subscriptions>
             </sending>
         </newsletter>
     </default>

--- a/app/code/core/Mage/Newsletter/etc/system.xml
+++ b/app/code/core/Mage/Newsletter/etc/system.xml
@@ -118,6 +118,32 @@
                         </un_email_template>
                     </fields>
                 </subscription>
+                <sending translate="label">
+                    <label>Sending Options</label>
+                    <frontend_type>text</frontend_type>
+                    <sort_order>10</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>1</show_in_website>
+                    <show_in_store>1</show_in_store>
+                    <fields>
+                        <count_of_queue translate="label">
+                            <label>Count of Queue per Sending Process</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>1</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </count_of_queue>
+                        <count_of_subscriptions translate="label">
+                            <label>Count of Queue per Sending Process</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>2</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </count_of_subscriptions>
+                    </fields>
+                </sending>
             </groups>
         </newsletter>
     </sections>


### PR DESCRIPTION
If you'll send a newsletter via Magento core functionality, Magento sends 20 emails per default and waits for the next cronjob to send the next 20 mails and so on. It would be great to make the two variables `$countOfQueue` and `$countOfSubscritions` configurable via system configuration.
