### PR TITLE
Refactored secure base_url logic

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Web/Usesecure.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Web/Usesecure.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * LICENSE: $license_text$
+ *
+ * @author    Axel Helmert <ah@luka.de>
+ * @copyright Copyright (c) 2012 LUKA netconsult GmbH (www.luka.de)
+ * @license   $license$
+ * @version   $Id$
+ */
+
+class Mage_Adminhtml_Model_System_Config_Source_Web_Usesecure
+{
+    /**
+     * Options getter
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return array(
+            array('value' => Mage_Core_Model_Store::WEB_FRONTEND_INSECURE, 'label'=>Mage::helper('adminhtml')->__('Disabled')),
+            array('value' => Mage_Core_Model_Store::WEB_FRONTEND_SECURE_PARTIALLY, 'label'=>Mage::helper('adminhtml')->__('Enabled for pages consuming sensitive user data')),
+            array('value' => Mage_Core_Model_Store::WEB_FRONTEND_SECURE_ALL, 'label'=>Mage::helper('adminhtml')->__('Enabled for all Pages')),
+        );
+    }
+
+    /**
+     * Get options in "key-value" format
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return array(
+            Mage_Core_Model_Store::WEB_FRONTEND_INSECURE => Mage::helper('adminhtml')->__('Disabled'),
+            Mage_Core_Model_Store::WEB_FRONTEND_SECURE_PARTIALLY => Mage::helper('adminhtml')->__('Enabled for pages consuming sensitive user data'),
+            Mage_Core_Model_Store::WEB_FRONTEND_SECURE_ALL => Mage::helper('adminhtml')->__('Enabled for all Pages'),
+        );
+    }
+}

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Web/Usesecure.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Web/Usesecure.php
@@ -1,7 +1,25 @@
 <?php
 /**
- * LICENSE: $license_text$
+ * Magento
  *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magentocommerce.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magentocommerce.com for more information.
+ *
+ * @category  Mage
+ * @package   Mage_Adminhtml
  * @author    Axel Helmert <ah@luka.de>
  * @copyright Copyright (c) 2012 LUKA netconsult GmbH (www.luka.de)
  * @license   $license$

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -1474,8 +1474,8 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
      * "Secure" should not be confused with https protocol, it is about web/secure/*_url settings usage only
      *
      * TODO: Update doc block - it is indeed https related and will result in a
-     *       Redirect loop when Use Secure in * is enabled and a http address
-     *       instead of an https address is set as secure url
+     *       Redirect loop when Use Secure in Frontend/Admin is enabled and a http address
+     *       instead of a https address is set as secure url
      *       Updated system.xml by adding a comment related to this issue
      *
      * @param string $url
@@ -1487,7 +1487,8 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
             return false;
         }
 
-        if (Mage::getStoreConfigFlag(Mage_Core_Model_Store::XML_PATH_SECURE_ENTIRE_FRONTEND)) {
+        // Check if entire store should be secure
+        if (Mage::getStoreConfig(Mage_Core_Model_Store::XML_PATH_SECURE_IN_FRONTEND) == Mage_Core_Model_Store::WEB_FRONTEND_SECURE_ALL) {
             return true;
         }
 

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -1473,6 +1473,11 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
      * Check whether given path should be secure according to configuration security requirements for URL
      * "Secure" should not be confused with https protocol, it is about web/secure/*_url settings usage only
      *
+     * TODO: Update doc block - it is indeed https related and will result in a
+     *       Redirect loop when Use Secure in * is enabled and a http address
+     *       instead of an https address is set as secure url
+     *       Updated system.xml by adding a comment related to this issue
+     *
      * @param string $url
      * @return bool
      */
@@ -1480,6 +1485,10 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     {
         if (!Mage::getStoreConfigFlag(Mage_Core_Model_Store::XML_PATH_SECURE_IN_FRONTEND)) {
             return false;
+        }
+
+        if (Mage::getStoreConfigFlag(Mage_Core_Model_Store::XML_PATH_SECURE_ENTIRE_FRONTEND)) {
+            return true;
         }
 
         if (!isset($this->_secureUrlCache[$url])) {

--- a/app/code/core/Mage/Core/Model/Cookie.php
+++ b/app/code/core/Mage/Core/Model/Cookie.php
@@ -183,7 +183,8 @@ class Mage_Core_Model_Cookie
      */
     public function isSecure()
     {
-        if ($this->getStore()->isAdmin() || (bool)$this->getStore()->getConfig(Mage_Core_Model_Store::XML_PATH_SECURE_ENTIRE_FRONTEND)) {
+        if ($this->getStore()->isAdmin()
+          || ($this->getStore()->getConfig(Mage_Core_Model_Store::XML_PATH_SECURE_IN_FRONTEND) == Mage_Core_Model_Store::WEB_FRONTEND_SECURE_ALL)) {
             return $this->_getRequest()->isSecure();
         }
         return false;

--- a/app/code/core/Mage/Core/Model/Cookie.php
+++ b/app/code/core/Mage/Core/Model/Cookie.php
@@ -183,7 +183,7 @@ class Mage_Core_Model_Cookie
      */
     public function isSecure()
     {
-        if ($this->getStore()->isAdmin()) {
+        if ($this->getStore()->isAdmin() || (bool)$this->getStore()->getConfig(Mage_Core_Model_Store::XML_PATH_SECURE_ENTIRE_FRONTEND)) {
             return $this->_getRequest()->isSecure();
         }
         return false;

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -58,12 +58,18 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
     const XML_PATH_UNSECURE_BASE_URL      = 'web/unsecure/base_url';
     const XML_PATH_SECURE_BASE_URL        = 'web/secure/base_url';
     const XML_PATH_SECURE_IN_FRONTEND     = 'web/secure/use_in_frontend';
-    const XML_PATH_SECURE_ENTIRE_FRONTEND = 'web/secure/entire_frontend';
     const XML_PATH_SECURE_IN_ADMINHTML    = 'web/secure/use_in_adminhtml';
     const XML_PATH_SECURE_BASE_LINK_URL   = 'web/secure/base_link_url';
     const XML_PATH_UNSECURE_BASE_LINK_URL = 'web/unsecure/base_link_url';
     const XML_PATH_OFFLOADER_HEADER       = 'web/secure/offloader_header';
     const XML_PATH_PRICE_SCOPE            = 'catalog/price/scope';
+
+    /**
+     * Secure frontend url option constants
+     */
+    const WEB_FRONTEND_INSECURE = 0;
+    const WEB_FRONTEND_SECURE_PARTIALLY = 1;
+    const WEB_FRONTEND_SECURE_ALL = 2;
 
     /**
      * Price scope constants

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -58,6 +58,7 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
     const XML_PATH_UNSECURE_BASE_URL      = 'web/unsecure/base_url';
     const XML_PATH_SECURE_BASE_URL        = 'web/secure/base_url';
     const XML_PATH_SECURE_IN_FRONTEND     = 'web/secure/use_in_frontend';
+    const XML_PATH_SECURE_ENTIRE_FRONTEND = 'web/secure/entire_frontend';
     const XML_PATH_SECURE_IN_ADMINHTML    = 'web/secure/use_in_adminhtml';
     const XML_PATH_SECURE_BASE_LINK_URL   = 'web/secure/base_link_url';
     const XML_PATH_UNSECURE_BASE_LINK_URL = 'web/unsecure/base_link_url';

--- a/app/code/core/Mage/Core/etc/system.xml
+++ b/app/code/core/Mage/Core/etc/system.xml
@@ -1303,8 +1303,9 @@
                             <show_in_store>1</show_in_store>
                             <comment>&lt;strong style="color:red"&gt;Warning!&lt;/strong&gt; When using CDN, in some cases JavaScript may not run properly if CDN is not in your subdomain</comment>
                         </base_js_url>
-                        <use_in_frontend translate="label">
+                        <use_in_frontend translate="label comment">
                             <label>Use Secure URLs in Frontend</label>
+                            <comment>Please make sure you've set an https:// address in secure url settings or this will cause a redirect loop on secure pages.</comment>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <backend_model>adminhtml/system_config_backend_secure</backend_model>
@@ -1313,6 +1314,19 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </use_in_frontend>
+                        
+                        <entire_frontend translate="label comment">
+                            <label>Secure URLs for every page in Frontend</label>
+                            <comment>Will enable HTTPS for every page when use Secure URLs in Frontend is enabled.</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <backend_model>adminhtml/system_config_backend_secure</backend_model>
+                            <sort_order>61</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </entire_frontend>
+                     
                         <use_in_adminhtml translate="label">
                             <label>Use Secure URLs in Admin</label>
                             <frontend_type>select</frontend_type>

--- a/app/code/core/Mage/Core/etc/system.xml
+++ b/app/code/core/Mage/Core/etc/system.xml
@@ -1303,29 +1303,18 @@
                             <show_in_store>1</show_in_store>
                             <comment>&lt;strong style="color:red"&gt;Warning!&lt;/strong&gt; When using CDN, in some cases JavaScript may not run properly if CDN is not in your subdomain</comment>
                         </base_js_url>
+                        
                         <use_in_frontend translate="label comment">
                             <label>Use Secure URLs in Frontend</label>
                             <comment>Please make sure you've set an https:// address in secure url settings or this will cause a redirect loop on secure pages.</comment>
                             <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <source_model>adminhtml/system_config_source_web_usesecure</source_model>
                             <backend_model>adminhtml/system_config_backend_secure</backend_model>
                             <sort_order>60</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </use_in_frontend>
-                        
-                        <entire_frontend translate="label comment">
-                            <label>Secure URLs for every page in Frontend</label>
-                            <comment>Will enable HTTPS for every page when use Secure URLs in Frontend is enabled.</comment>
-                            <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <backend_model>adminhtml/system_config_backend_secure</backend_model>
-                            <sort_order>61</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </entire_frontend>
                      
                         <use_in_adminhtml translate="label">
                             <label>Use Secure URLs in Admin</label>


### PR DESCRIPTION
As discussed: The last implementation may confuse users. See pull request #96 for details.
Refactored logics to the following solution:
- Merged second config option to secure the entire store into
  use_in_frontend
- Added source model for use secure base_url in frontend option

Resolves #91
Please review and pull if acceptable.
