### PR TITLE
Add a .htaccess to the shell folder

### DIFF
--- a/shell/.htaccess
+++ b/shell/.htaccess
@@ -1,0 +1,2 @@
+Order deny,allow
+Deny from all


### PR DESCRIPTION
shell, like all other folders not intended for web access, should have a .htaccess denying access. There's a check in abstract.php for shell scripts that inherit from Mage_Shell_Abstract, but it's also pretty common to have other shell scripts in there.
