### PR TITLE
Fixed wrong image url for wysiwyg editor in multistore installation

### DIFF
--- a/app/code/core/Mage/Cms/Helper/Wysiwyg/Images.php
+++ b/app/code/core/Mage/Cms/Helper/Wysiwyg/Images.php
@@ -172,7 +172,8 @@ class Mage_Cms_Helper_Wysiwyg_Images extends Mage_Core_Helper_Abstract
     public function getImageHtmlDeclaration($filename, $renderAsTag = false)
     {
         $fileurl = $this->getCurrentUrl() . $filename;
-        $mediaPath = str_replace(Mage::getBaseUrl('media'), '', $fileurl);
+        $baseurl = Mage::app()->getStore($this->_storeId)->getBaseUrl('media');
+        $mediaPath = str_replace($baseurl, '', $fileurl);
         $directive = sprintf('{{media url="%s"}}', $mediaPath);
         if ($renderAsTag) {
             $html = sprintf('<img src="%s" alt="" />', $this->isUsingStaticUrlsAllowed() ? $fileurl : $directive);


### PR DESCRIPTION
When you use different media urls depending on your store frontends, you will get a 404 for images you add f.e. to your product description, because media url of the default store will be used for replacement in media include tag.

See http://www.netresearch.de/blog/falsche-bild-url-bei-multi-stores-ein-magento-core-patch/ (german) for more details.
