### PR TITLE
Bug - In Mage_Eav_Model_Attribute_Data_Text:67

### DIFF
--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Text.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Text.php
@@ -64,7 +64,7 @@ class Mage_Eav_Model_Attribute_Data_Text extends Mage_Eav_Model_Attribute_Data_A
             $value = $this->getEntity()->getDataUsingMethod($attribute->getAttributeCode());
         }
 
-        if ($attribute->getIsRequired() && empty($value)) {
+        if ($attribute->getIsRequired() && empty($value) && $value !== '0') {
             $errors[] = Mage::helper('eav')->__('"%s" is a required value.', $label);
         }
 


### PR DESCRIPTION
The call to empty($value) returns true of the value is '0' (The string of the character zero). This prevents you from setting a required text field to zero, which should be a valid value.

Action:
Create a required text attribute on a product. Assign to an attribute set. Go to edit a product. Set the value to zero. Try to save the product.
Expected: Saves the product.
Actual: Error stating {attribute_name} is a required value.

Simple fix. Worried the use of empty() having other side effects.
