### PR TITLE
Bug - In Mage_Sales_Model_Order_Invoice_Total_Shipping:49

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Total/Shipping.php
@@ -46,7 +46,7 @@ class Mage_Sales_Model_Order_Invoice_Total_Shipping extends Mage_Sales_Model_Ord
              * Check shipping amount in previus invoices
              */
             foreach ($invoice->getOrder()->getInvoiceCollection() as $previusInvoice) {
-                if ($previusInvoice->getShippingAmount() && !$previusInvoice->isCanceled()) {
+                if ($previusInvoice->getShippingAmount() > 0 && !$previusInvoice->isCanceled()) {
                     return $this;
                 }
             }


### PR DESCRIPTION
 The test on $previusInvoice->getShippingAmount() results in TRUE even if the amount is 0, as the value is pulled in as a string "0.0000". Simple fix is to add a comparison that causes the value to be cast.

Without the fix, if you create a partial invoice but don't include the shipping (not possible through UI currently, but possible programmatically) when you create a subsequent invoice the shipping will not be added in.

Example-
Action:
Create order with 2 items, 1 virtual, 1 simple. Invoice just the virtual product and programmatically force it to not include the shipping. Later, invoice the simple product.

Expected: The second invoice includes the shipping that the first did not.
Actual: It does not include the shipping.
After fix : It includes the shipping.
