### PR TITLE
PHP 5.4: Fixing contrustructor signature

### DIFF
--- a/lib/Zend/Pdf/FileParserDataSource/File.php
+++ b/lib/Zend/Pdf/FileParserDataSource/File.php
@@ -72,7 +72,7 @@ class Zend_Pdf_FileParserDataSource_File extends Zend_Pdf_FileParserDataSource
      * @param string $filePath Fully-qualified path to the file.
      * @throws Zend_Pdf_Exception
      */
-    public function __construct($filePath)
+    public function __construct($filePath = null)
     {
         if (! (is_file($filePath) || is_link($filePath))) {
             #require_once 'Zend/Pdf/Exception.php';


### PR DESCRIPTION
This patch fixes the constructor signature which would otherwise lead to this error under PHP 5.4:

```
PHP Fatal error:  Declaration of Zend_Pdf_FileParserDataSource_File::__construct() must be compatible with Zend_Pdf_FileParserDataSource::__construct() in /var/www/akjumii/public/shop/lib/Zend/Pdf/FileParserDataSource/File.php on line 41
```

The problem is, that `Zend_Pdf_FileParserDataSource` declares an abstract constructor, which is stupid but it is how it is.
