### PR TITLE
Allow setting apply_to in setup

### DIFF
--- a/app/code/core/Mage/Eav/Model/Entity/Setup.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Setup.php
@@ -608,6 +608,7 @@ class Mage_Eav_Model_Entity_Setup extends Mage_Core_Model_Resource_Setup
             'is_global'       => $this->_getValue($attr, 'global',
                                      Mage_Catalog_Model_Resource_Eav_Attribute::SCOPE_GLOBAL
                                  ),
+            'apply_to'        => $this->_getValue($attr, 'apply_to'),
         );
 
         return $data;


### PR DESCRIPTION
When creating attributes it is currently not possible to define apply_to (the products an attribute should be used for) for catalog_eav_attribute data.
