### PR TITLE
Adding support for local.xml override of DB data

### DIFF
--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -352,6 +352,17 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
             Varien_Profiler::start('config/load-db');
             $dbConf = $this->getResourceModel();
             $dbConf->loadToXml($this);
+
+            /**
+             * Prevent local.xml directives overwriting
+             */
+            $mergeConfig = clone $this->_prototype;
+            $this->_isLocalConfigLoaded = $mergeConfig->loadFile($this->getOptions()->getEtcDir() . DS . 'local.xml');
+            if ($this->_isLocalConfigLoaded) {
+                $this->extend($mergeConfig);
+            }
+
+            $this->applyExtends();
             Varien_Profiler::stop('config/load-db');
         }
         return $this;


### PR DESCRIPTION
By loading the local.xml file after loading the DB config data into the
global config XML object you can specify data in the local.xml file that
cannot be changed via the DB config.

You also gain the ability to override data from a shared DB on a
per-install basis.  This can be useful in development, testing, and
clustering.
