### PR TITLE
Fix bad usage of 'false' as a string instead of a boolean

### DIFF
--- a/app/design/adminhtml/default/default/template/api/rolesedit.phtml
+++ b/app/design/adminhtml/default/default/template/api/rolesedit.phtml
@@ -70,7 +70,7 @@ Ext.EventManager.onDocumentReady(function() {
     var root = new Ext.tree.TreeNode({
         text: 'root',
         draggable:false,
-        checked:'false',
+        checked:false,
         id:'__root__',
         uiProvider: Ext.tree.CheckboxNodeUI
     });

--- a/app/design/adminhtml/default/default/template/api2/attribute/resource.phtml
+++ b/app/design/adminhtml/default/default/template/api2/attribute/resource.phtml
@@ -84,7 +84,7 @@ Ext.EventManager.onDocumentReady(function() {
     var root = new Ext.tree.TreeNode({
         text: 'root',
         draggable:false,
-        checked:'false',
+        checked:false,
         id:'__root__',
         uiProvider: Ext.tree.CheckboxNodeUI
     });

--- a/app/design/adminhtml/default/default/template/permissions/rolesedit.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/rolesedit.phtml
@@ -79,7 +79,7 @@ Ext.EventManager.onDocumentReady(function() {
     var root = new Ext.tree.TreeNode({
         text: 'root',
         draggable:false,
-        checked:'false',
+        checked:false,
         id:'__root__',
         uiProvider: Ext.tree.CheckboxNodeUI
     });


### PR DESCRIPTION
The initial config for the tree node root element used in role resource editing
was broken.  The 'checked' attribute was being set to a string of the word 'false'
when it should have been the false boolean literal.  This was causing the root
node of the tree to be included in the selected resource list.  The bug is minor
and had no serious side-effects, but was still a bug that caused `__root__` to be
sent as a selected resource.
