### PR TITLE
Bugfix: do not set object as category ID

### DIFF
--- a/app/code/core/Mage/Catalog/Block/Product/List.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List.php
@@ -71,7 +71,7 @@ class Mage_Catalog_Block_Product_List extends Mage_Catalog_Block_Product_Abstrac
                 // if the product is associated with any category
                 if ($categories->count()) {
                     // show products from this category
-                    $this->setCategoryId(current($categories->getIterator()));
+                    $this->setCategoryId(current($categories->getIterator())->getId());
                 }
             }
 


### PR DESCRIPTION
If a product list block is currently used on a product page, there will be an error because the category ID is set to an object. As soon as the category is loaded in line 80, there will be an error like
Warning: PDO::quote() expects parameter 1 to be string, object given  in /var/www/site/lib/Zend/Db/Adapter/Pdo/Abstract.php on line 296
The method setCategoryId() has to be called with the ID of the category, not the category object itself.
