### PR TITLE
Simplistic 'fix' for bundle import saving bug

### DIFF
--- a/app/code/core/Mage/Bundle/Model/Selection.php
+++ b/app/code/core/Mage/Bundle/Model/Selection.php
@@ -70,7 +70,8 @@ class Mage_Bundle_Model_Selection extends Mage_Core_Model_Abstract
      */
     protected function _beforeSave()
     {
-        $storeId = Mage::registry('product')->getStoreId();
+        $product = Mage::registry('product');
+        $storeId = ($product instanceof Mage_Catalog_Model_Product ? $product->getStoreId() : null);
         if (!Mage::helper('catalog')->isPriceGlobal() && $storeId) {
             $this->setWebsiteId(Mage::app()->getStore($storeId)->getWebsiteId());
             $this->getResource()->saveSelectionPrice($this);


### PR DESCRIPTION
If you attempt to save a bundle without the 'product' registry entry set
to the instance of the bundle, the associated selections objects fail to
save do to a reference to the product via the registry. This is the exact
situation you run into when importing via DataFlow.

There is probably a much better fix for this problem, but this one is
enough to make importing updates via DataFlow work.

Looking at the Magento2 code it seems they have a website_id attached to
the selection object being saved. Perhaps further research will show this
to always be the case in Magento1 as well and we could instead use that
method.
