### PR TITLE
fix for install error "PHP Extensions "0" must be loaded.

### DIFF
--- a/app/code/core/Mage/Install/etc/config.xml
+++ b/app/code/core/Mage/Install/etc/config.xml
@@ -69,7 +69,7 @@
                 <initStatements>SET NAMES utf8</initStatements>
                 <min_version>4.1.20</min_version>
                 <extensions>
-                    <pdo_mysql/>
+                    <pdo_mysql>1</pdo_mysql>
                 </extensions>
             </mysql4>
         </databases>


### PR DESCRIPTION
Since PHP Version 5.4.10 appears an error on during the install process.
![bildschirmfoto 2013-05-04 um 20 40 46](https://f.cloud.github.com/assets/907458/463354/7b3d0e48-b552-11e2-8ccf-a0fe8a3562c9.png)

A simple fix resolves the problem. Change in the File /app/code/core/Mage/Install/etc/config.xml  the Line 

``` xml
<pdo_mysql/> to <pdo_mysql>1</pdo_mysql>
```

After the fix I've tested the install process on an older PHP Version (5.3.4) and a newer one (5.4.10), everything worked out perfectly
