### PR TITLE
Add Australian regions to the default list

### DIFF
--- a/app/code/core/Mage/Directory/data/directory_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Directory/data/directory_setup/data-install-1.6.0.0.php
@@ -283,7 +283,11 @@ $data = array(
     array('LT', 'LT-MR', 'Marijampolės Apskritis'), array('LT', 'LT-PN', 'Panevėžio Apskritis'),
     array('LT', 'LT-SA', 'Šiaulių Apskritis'), array('LT', 'LT-TA', 'Tauragės Apskritis'),
     array('LT', 'LT-TE', 'Telšių Apskritis'), array('LT', 'LT-UT', 'Utenos Apskritis'),
-    array('LT', 'LT-VL', 'Vilniaus Apskritis')
+    array('LT', 'LT-VL', 'Vilniaus Apskritis'),
+    array('AU', 'ACT', 'Australian Capital Territory'), array('AU', 'NSW', 'New South Wales'),
+    array('AU', 'NT', 'Northern Territory'), array('AU', 'QLD', 'Queensland'),
+    array('AU', 'SA', 'South Australia'), array('AU', 'TAS', 'Tasmania'),
+    array('AU', 'VIC', 'Victoria'), array('AU', 'WA', 'Western Australia'),
 );
 
 foreach ($data as $row) {


### PR DESCRIPTION
The regions have been added to the data-install-1.6.0.0.php file to
ensure better forward compatibility with future versions of Magento,
which may create new versions of the Mage_Directory module, along with
new data-upgrade files, which will overwrite anything we put in here and
require a merge. This makes future upstream merges easier at the expense
of existing websites not automatically getting the changes as part of an
upgrade.

If you are already running an existing website you can add these regions
by installing the Fontis_Australia extension, or adding the regions
individually.
