### PR TITLE
Feature/block cache

### DIFF
--- a/app/code/core/Mage/Catalog/Block/Product/Compare/Sidebar.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Compare/Sidebar.php
@@ -48,6 +48,34 @@ class Mage_Catalog_Block_Product_Compare_Sidebar extends Mage_Catalog_Block_Prod
     protected function _construct()
     {
         $this->setId('compare');
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG)
+        ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+
+        // Get list of compared product id
+        $items = array();
+        foreach ($this->getItems() as $item) {
+            $items[] = $item->getId();
+        }
+
+        return array(
+            'COMPARE_SIDEBAR',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            implode("_", $items)
+        );
     }
 
     /**

--- a/app/code/core/Mage/Catalog/Block/Product/List/Upsell.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Upsell.php
@@ -49,6 +49,37 @@ class Mage_Catalog_Block_Product_List_Upsell extends Mage_Catalog_Block_Product_
 
     protected $_itemLimits = array();
 
+    protected function _construct()
+    {
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG,
+                                     Mage_Sales_Model_Quote::CACHE_TAG,
+                                     Mage_Sales_Model_Quote::CACHE_TAG . "_" . Mage::getSingleton('checkout/session')->getQuoteId())
+        ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+        $product = Mage::registry('product');
+
+        return array(
+            'PRODUCT_UPSELL',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            $product->getId(),
+            Mage::getSingleton('checkout/session')->getQuoteId(),
+            $this->getItemLimit('upsell')
+        );
+    }
+
     protected function _prepareData()
     {
         $product = Mage::registry('product');

--- a/app/code/core/Mage/Catalog/Block/Product/Price.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Price.php
@@ -38,12 +38,21 @@ class Mage_Catalog_Block_Product_Price extends Mage_Core_Block_Template
 
     protected function _construct()
     {
-        $this->addData(array(
-            'cache_lifetime'=> false,
-            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG,
-                                     Mage_Catalog_Model_Product::CACHE_TAG,
-                                     Mage_Catalog_Model_Product::CACHE_TAG . "_" . $this->getProduct()->getId())
+
+        if($product = $this->getProduct()) {
+            $this->addData(array(
+                'cache_lifetime'=> false,
+                'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG,
+                                         Mage_Catalog_Model_Product::CACHE_TAG,
+                                         Mage_Catalog_Model_Product::CACHE_TAG . "_" . $product->getId())
             ));
+        } else {
+            $this->addData(array(
+                'cache_lifetime'=> false,
+                'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG,
+                                         Mage_Catalog_Model_Product::CACHE_TAG)
+            ));
+        }
     }
 
     /**

--- a/app/code/core/Mage/Catalog/Block/Product/Price.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Price.php
@@ -70,7 +70,8 @@ class Mage_Catalog_Block_Product_Price extends Mage_Core_Block_Template
             Mage::getDesign()->getTheme('template'),
             $this->getProduct()->getId(),
             $this->getProduct()->getCategoryId(),
-            Mage::getSingleton('customer/session')->getCustomerGroupId()
+            Mage::getSingleton('customer/session')->getCustomerGroupId(),
+            $this->getTemplate()
         );
     }
 

--- a/app/code/core/Mage/Catalog/Block/Product/Price.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Price.php
@@ -36,6 +36,35 @@ class Mage_Catalog_Block_Product_Price extends Mage_Core_Block_Template
     protected $_priceDisplayType = null;
     protected $_idSuffix = '';
 
+    protected function _construct()
+    {
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG,
+                                     Mage_Catalog_Model_Product::CACHE_TAG,
+                                     Mage_Catalog_Model_Product::CACHE_TAG . "_" . $this->getProduct()->getId())
+            ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+        return array(
+            'PRODUCT_PRICE',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            $this->getProduct()->getId(),
+            $this->getProduct()->getCategoryId(),
+            Mage::getSingleton('customer/session')->getCustomerGroupId()
+        );
+    }
+
     /**
      * Retrieve product
      *

--- a/app/code/core/Mage/Catalog/Block/Product/View/Attributes.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Attributes.php
@@ -36,6 +36,33 @@ class Mage_Catalog_Block_Product_View_Attributes extends Mage_Core_Block_Templat
 {
     protected $_product = null;
 
+    protected function _construct()
+    {
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG,
+                Mage_Catalog_Model_Product::CACHE_TAG,
+                Mage_Catalog_Model_Product::CACHE_TAG . '_' . $this->getProduct()->getId())
+        ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+        return array(
+            'PRODUCT_VIEW_ATTRIBUTES',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            $this->getProduct()->getId()
+        );
+    }
+
     function getProduct()
     {
         if (!$this->_product) {

--- a/app/code/core/Mage/Catalog/Block/Product/View/Description.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Description.php
@@ -36,6 +36,33 @@ class Mage_Catalog_Block_Product_View_Description extends Mage_Core_Block_Templa
 {
     protected $_product = null;
 
+    protected function _construct()
+    {
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG,
+                                     Mage_Catalog_Model_Product::CACHE_TAG,
+                                     Mage_Catalog_Model_Product::CACHE_TAG . '_' . $this->getProduct()->getId())
+        ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+        return array(
+            'PRODUCT_VIEW_DESCRIPTION',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            $this->getProduct()->getId()
+        );
+    }
+
     function getProduct()
     {
         if (!$this->_product) {

--- a/app/code/core/Mage/Catalog/Block/Product/View/Media.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Media.php
@@ -40,6 +40,33 @@ class Mage_Catalog_Block_Product_View_Media extends Mage_Catalog_Block_Product_V
      */
     protected $_isGalleryDisabled;
 
+    protected function _construct()
+    {
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG,
+                Mage_Catalog_Model_Product::CACHE_TAG,
+                Mage_Catalog_Model_Product::CACHE_TAG . '_' . $this->getProduct()->getId())
+        ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+        return array(
+            'PRODUCT_VIEW_MEDIA',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            $this->getProduct()->getId()
+        );
+    }
+
     /**
      * Retrieve list of gallery images
      *

--- a/app/code/core/Mage/Catalog/Block/Product/View/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Type/Configurable.php
@@ -48,6 +48,35 @@ class Mage_Catalog_Block_Product_View_Type_Configurable extends Mage_Catalog_Blo
      */
     protected $_resPrices   = array();
 
+    protected function _construct()
+    {
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG,
+                Mage_Catalog_Model_Product::CACHE_TAG,
+                Mage_Catalog_Model_Product::CACHE_TAG . "_" . $this->getProduct()->getId())
+        ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+        return array(
+            'PRODUCT_VIEW_TYPE_CONFIGURABLE',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            $this->getProduct()->getId(),
+            $this->getProduct()->getCategoryId(),
+            Mage::getSingleton('customer/session')->getCustomerGroupId()
+        );
+    }
+
     /**
      * Get allowed attributes
      *

--- a/app/code/core/Mage/Catalog/Block/Product/View/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Type/Configurable.php
@@ -73,7 +73,8 @@ class Mage_Catalog_Block_Product_View_Type_Configurable extends Mage_Catalog_Blo
             Mage::getDesign()->getTheme('template'),
             $this->getProduct()->getId(),
             $this->getProduct()->getCategoryId(),
-            Mage::getSingleton('customer/session')->getCustomerGroupId()
+            Mage::getSingleton('customer/session')->getCustomerGroupId(),
+            $this->getTemplate()
         );
     }
 

--- a/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer.php
@@ -56,6 +56,34 @@ class Mage_Checkout_Block_Cart_Item_Renderer extends Mage_Core_Block_Template
      */
     protected $_ignoreProductUrl = false;
 
+    public function _construct()
+    {
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG,
+                Mage_Sales_Model_Quote::CACHE_TAG,
+                Mage_Sales_Model_Quote::CACHE_TAG . "_" . Mage::getSingleton('checkout/session')->getQuoteId())
+        ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+        return array(
+            'CART_ITEM_RENDERER',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            $this->getTemplate(),
+            Mage::getSingleton('checkout/session')->getQuoteId()
+        );
+    }
+
     /**
      * Set item for render
      *

--- a/app/code/core/Mage/Checkout/Block/Cart/Sidebar.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Sidebar.php
@@ -45,6 +45,16 @@ class Mage_Checkout_Block_Cart_Sidebar extends Mage_Checkout_Block_Cart_Abstract
         $this->addItemRender('default', 'checkout/cart_item_renderer', 'checkout/cart/sidebar/default.phtml');
     }
 
+    public function _construct()
+    {
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG,
+                                     Mage_Sales_Model_Quote::CACHE_TAG,
+                                     Mage_Sales_Model_Quote::CACHE_TAG . "_" . $this->getQuote()->getId())
+        ));
+    }
+
     /**
      * Retrieve count of display recently added items
      *

--- a/app/code/core/Mage/Checkout/Block/Links.php
+++ b/app/code/core/Mage/Checkout/Block/Links.php
@@ -33,6 +33,32 @@
  */
 class Mage_Checkout_Block_Links extends Mage_Core_Block_Template
 {
+
+    public function _construct()
+    {
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG)
+        ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+        return array(
+            'CART_CHECKOUT_LINKS',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            $this->getSummaryQty()
+        );
+    }
+
     /**
      * Add shopping cart link to parent block
      *

--- a/app/code/core/Mage/Page/Block/Html/Breadcrumbs.php
+++ b/app/code/core/Mage/Page/Block/Html/Breadcrumbs.php
@@ -77,7 +77,6 @@ class Mage_Page_Block_Html_Breadcrumbs extends Mage_Core_Block_Template
             (int)Mage::app()->getStore()->isCurrentlySecure(),
             Mage::getDesign()->getPackageName(),
             Mage::getDesign()->getTheme('template'),
-            Mage::getSingleton('customer/session')->isLoggedIn(),
             Mage::app()->getRequest()->getPathInfo()
         );
     }

--- a/app/code/core/Mage/Page/Block/Html/Breadcrumbs.php
+++ b/app/code/core/Mage/Page/Block/Html/Breadcrumbs.php
@@ -56,6 +56,32 @@ class Mage_Page_Block_Html_Breadcrumbs extends Mage_Core_Block_Template
         $this->setTemplate('page/html/breadcrumbs.phtml');
     }
 
+    protected function _construct()
+    {
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG, Mage_Catalog_Model_Category::CACHE_TAG, Mage_Catalog_Model_Product::CACHE_TAG)
+        ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+        return array(
+            'BREADCRUMBS',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            Mage::getSingleton('customer/session')->isLoggedIn(),
+            Mage::app()->getRequest()->getPathInfo()
+        );
+    }
+
     function addCrumb($crumbName, $crumbInfo, $after = false)
     {
         $this->_prepareArray($crumbInfo, array('label', 'title', 'link', 'first', 'last', 'readonly'));

--- a/app/code/core/Mage/Page/Block/Html/Header.php
+++ b/app/code/core/Mage/Page/Block/Html/Header.php
@@ -36,6 +36,27 @@ class Mage_Page_Block_Html_Header extends Mage_Core_Block_Template
     public function _construct()
     {
         $this->setTemplate('page/html/header.phtml');
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG)
+        ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+        return array(
+            'PAGE_HEADER',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            Mage::helper('checkout/cart')->getSummaryCount()
+        );
     }
 
     /**

--- a/app/code/core/Mage/Page/Block/Html/Topmenu.php
+++ b/app/code/core/Mage/Page/Block/Html/Topmenu.php
@@ -46,6 +46,10 @@ class Mage_Page_Block_Html_Topmenu extends Mage_Core_Block_Template
     public function _construct()
     {
         $this->_menu = new Varien_Data_Tree_Node(array(), 'root', new Varien_Data_Tree());
+
+        $this->addData(array(
+            'cache_lifetime' => false,
+        ));
     }
 
     /**
@@ -202,5 +206,48 @@ class Mage_Page_Block_Html_Topmenu extends Mage_Core_Block_Template
         }
 
         return $classes;
+    }
+
+    /**
+     * Retrieve cache key data
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+        $shortCacheId = array(
+            'TOPMENU',
+            Mage::app()->getStore()->getId(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            Mage::getSingleton('customer/session')->getCustomerGroupId(),
+            'template' => $this->getTemplate(),
+            'name' => $this->getNameInLayout(),
+            $this->getCurrentEntityKey()
+        );
+        $cacheId = $shortCacheId;
+
+        $shortCacheId = array_values($shortCacheId);
+        $shortCacheId = implode('|', $shortCacheId);
+        $shortCacheId = md5($shortCacheId);
+
+        $cacheId['entity_key'] = $this->getCurrentEntityKey();
+        $cacheId['short_cache_id'] = $shortCacheId;
+
+        return $cacheId;
+    }
+
+    /**
+     * Retrieve current entity key
+     *
+     * @return int|string
+     */
+    public function getCurrentEntityKey()
+    {
+        if (null === $this->_currentEntityKey) {
+            $this->_currentEntityKey = Mage::registry('current_entity_key')
+                ? Mage::registry('current_entity_key') : Mage::app()->getStore()->getRootCategoryId();
+        }
+        return $this->_currentEntityKey;
     }
 }

--- a/app/code/core/Mage/Page/Block/Switch.php
+++ b/app/code/core/Mage/Page/Block/Switch.php
@@ -35,6 +35,31 @@ class Mage_Page_Block_Switch extends Mage_Core_Block_Template
 {
     protected $_storeInUrl;
 
+    public function _construct()
+    {
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG)
+        ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+        return array(
+            'STORE_SWITCH',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+        );
+    }
+
+
     public function getCurrentWebsiteId()
     {
         return Mage::app()->getStore()->getWebsiteId();

--- a/app/code/core/Mage/Paypal/Block/Logo.php
+++ b/app/code/core/Mage/Paypal/Block/Logo.php
@@ -29,6 +29,32 @@
  */
 class Mage_Paypal_Block_Logo extends Mage_Core_Block_Template
 {
+
+    public function _construct()
+    {
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG)
+        ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+        return array(
+            'PAYPAL_LOGO',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            $this->getLogoType()
+        );
+    }
+
     /**
      * Return URL for Paypal Landing page
      *

--- a/app/code/core/Mage/Poll/Block/ActivePoll.php
+++ b/app/code/core/Mage/Poll/Block/ActivePoll.php
@@ -33,6 +33,16 @@
 
 class Mage_Poll_Block_ActivePoll extends Mage_Core_Block_Template
 {
+
+    public function _construct()
+    {
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG)
+        ));
+    }
+
+
     /**
      * Poll templates
      *

--- a/app/code/core/Mage/Reports/Block/Product/Compared.php
+++ b/app/code/core/Mage/Reports/Block/Product/Compared.php
@@ -60,7 +60,7 @@ class Mage_Reports_Block_Product_Compared extends Mage_Reports_Block_Product_Abs
 
         // Get list of compared product id
         $items = array();
-        foreach ($this->getItems() as $item) {
+        foreach ($this->getItemsCollection() as $item) {
             $items[] = $item->getId();
         }
 

--- a/app/code/core/Mage/Reports/Block/Product/Compared.php
+++ b/app/code/core/Mage/Reports/Block/Product/Compared.php
@@ -42,6 +42,38 @@ class Mage_Reports_Block_Product_Compared extends Mage_Reports_Block_Product_Abs
      */
     protected $_indexName       = 'reports/product_index_compared';
 
+    protected function _construct()
+    {
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG)
+        ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+
+        // Get list of compared product id
+        $items = array();
+        foreach ($this->getItems() as $item) {
+            $items[] = $item->getId();
+        }
+
+        return array(
+            'RECENTLY_COMPARED',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            implode("_", $items)
+        );
+    }
+
     /**
      * Retrieve page size (count)
      *

--- a/app/code/core/Mage/Reports/Block/Product/Viewed.php
+++ b/app/code/core/Mage/Reports/Block/Product/Viewed.php
@@ -42,6 +42,38 @@ class Mage_Reports_Block_Product_Viewed extends Mage_Reports_Block_Product_Abstr
      */
     protected $_indexName       = 'reports/product_index_viewed';
 
+    protected function _construct()
+    {
+        $this->setId('compare');
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG)
+        ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+
+        // Get list of compared product id
+        $items = array();
+        foreach ($this->getItemsCollection() as $item) {
+            $items[] = $item->getId();
+        }
+
+        return array(
+            'PRODUCT_VIEWED',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            implode("_", $items)
+        );
+    }
     /**
      * Retrieve page size (count)
      *

--- a/app/code/core/Mage/Reports/Block/Product/Viewed.php
+++ b/app/code/core/Mage/Reports/Block/Product/Viewed.php
@@ -44,7 +44,6 @@ class Mage_Reports_Block_Product_Viewed extends Mage_Reports_Block_Product_Abstr
 
     protected function _construct()
     {
-        $this->setId('compare');
         $this->addData(array(
             'cache_lifetime'=> false,
             'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG)
@@ -59,7 +58,7 @@ class Mage_Reports_Block_Product_Viewed extends Mage_Reports_Block_Product_Abstr
     public function getCacheKeyInfo()
     {
 
-        // Get list of compared product id
+        // Get list of viewed product id
         $items = array();
         foreach ($this->getItemsCollection() as $item) {
             $items[] = $item->getId();

--- a/app/code/core/Mage/Review/Block/Helper.php
+++ b/app/code/core/Mage/Review/Block/Helper.php
@@ -38,6 +38,35 @@ class Mage_Review_Block_Helper extends Mage_Core_Block_Template
         'short'   => 'review/helper/summary_short.phtml'
     );
 
+    protected function _construct()
+    {
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG,
+                                     Mage_Review_Model_Review::CACHE_TAG)
+        ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+        $product = $this->getProduct();
+
+        return array(
+            'REVIEW_HELPER',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            $product->getId(),
+            $product->getCategoryId()
+        );
+    }
+
     public function getSummaryHtml($product, $templateType, $displayIfNoReviews)
     {
         // pick template among available

--- a/app/code/core/Mage/Review/Model/Review.php
+++ b/app/code/core/Mage/Review/Model/Review.php
@@ -69,6 +69,8 @@ class Mage_Review_Model_Review extends Mage_Core_Model_Abstract
     const STATUS_PENDING        = 2;
     const STATUS_NOT_APPROVED   = 3;
 
+    const CACHE_TAG = 'review';
+
     protected function _construct()
     {
         $this->_init('review/review');

--- a/app/code/core/Mage/Sales/Block/Guest/Links.php
+++ b/app/code/core/Mage/Sales/Block/Guest/Links.php
@@ -47,4 +47,29 @@ class Mage_Sales_Block_Guest_Links extends Mage_Page_Block_Template_Links_Block
             parent::__construct();
         }
     }
+
+    public function _construct()
+    {
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG)
+        ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+        return array(
+            'SALES_GUEST_LINKS',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            Mage::getSingleton('customer/session')->isLoggedIn()
+        );
+    }
 }

--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -138,6 +138,8 @@
  */
 class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
 {
+    const CACHE_TAG = 'sales_quote';
+
     protected $_eventPrefix = 'sales_quote';
     protected $_eventObject = 'quote';
 
@@ -280,6 +282,8 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
          *      base_to_global & base_to_quote/base_to_order - must be used instead
          */
 
+        $this->cleanCache();
+
         $globalCurrencyCode  = Mage::app()->getBaseCurrencyCode();
         $baseCurrency = $this->getStore()->getBaseCurrency();
 
@@ -334,6 +338,17 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
         if (null !== $this->_payments) {
             $this->getPaymentsCollection()->save();
         }
+        return $this;
+    }
+
+    /**
+     * Clear sales quote cache for this quote id
+     *
+     * @return Mage_Catalog_Model_Product
+     */
+    public function cleanCache()
+    {
+        Mage::app()->cleanCache(self::CACHE_TAG . '_' .$this->getId());
         return $this;
     }
 

--- a/app/code/core/Mage/Tag/Block/Popular.php
+++ b/app/code/core/Mage/Tag/Block/Popular.php
@@ -39,6 +39,31 @@ class Mage_Tag_Block_Popular extends Mage_Core_Block_Template
     protected $_minPopularity;
     protected $_maxPopularity;
 
+    public function _construct()
+    {
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG)
+        ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+        return array(
+            'TAG_POPULAR',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+        );
+    }
+
+
     protected function _loadTags()
     {
         if (empty($this->_tags)) {

--- a/app/code/core/Mage/Tag/Block/Product/List.php
+++ b/app/code/core/Mage/Tag/Block/Product/List.php
@@ -35,6 +35,39 @@ class Mage_Tag_Block_Product_List extends Mage_Core_Block_Template
      */
     protected $_uniqueHtmlId = null;
 
+    protected function _construct()
+    {
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG,
+                Mage_Catalog_Model_Product::CACHE_TAG,
+                Mage_Catalog_Model_Product::CACHE_TAG . '_' . $this->getProductId())
+        ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+        $items = array();
+        foreach($this->getTags() as $item) {
+            $items[] = $item->getId();
+        }
+
+        return array(
+            'TAG_PRODUCT_LIST',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            $this->getProductId(),
+            implode('_', $items)
+        );
+    }
+
     public function getCount()
     {
         return count($this->getTags());

--- a/app/code/core/Mage/Wishlist/Block/Links.php
+++ b/app/code/core/Mage/Wishlist/Block/Links.php
@@ -40,6 +40,31 @@ class Mage_Wishlist_Block_Links extends Mage_Page_Block_Template_Links_Block
      */
     protected $_position = 30;
 
+    public function _construct()
+    {
+        $this->addData(array(
+            'cache_lifetime'=> false,
+            'cache_tags'    => array(Mage_Core_Model_Store::CACHE_TAG)
+        ));
+    }
+
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+        return array(
+            'WISHLIST_LINKS',
+            Mage::app()->getStore()->getId(),
+            (int)Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::getDesign()->getPackageName(),
+            Mage::getDesign()->getTheme('template'),
+            $this->_getItemCount()
+        );
+    }
+
     /**
      * @return string
      */

--- a/index.php
+++ b/index.php
@@ -70,11 +70,11 @@ require_once $mageFilename;
 
 #Varien_Profiler::enable();
 
-if (isset($_SERVER['MAGE_IS_DEVELOPER_MODE'])) {
+#if (isset($_SERVER['MAGE_IS_DEVELOPER_MODE'])) {
     Mage::setIsDeveloperMode(true);
-}
+#}
 
-#ini_set('display_errors', 1);
+ini_set('display_errors', 1);
 
 umask(0);
 


### PR DESCRIPTION
Magento only has block caching for top menu (catalog navigation) and the footer.

This branch works in order to add block caching to other blocks.

Very rudimentary tests suggest that the work so far can save up to 20% dispatch time on product pages.

In most cases this entails adding cache_lifetime, cache_tags and cache_key info. 

For sales_quote related items I've added a cache tag to the model and also a cleanCache call in beforeSave.  This will then delete the cache for certain quote (by its cache tag)
